### PR TITLE
fix(XIC): strip .htrms and other vendor exts from RawFileName

### DIFF
--- a/R/XIC_plot_module.R
+++ b/R/XIC_plot_module.R
@@ -378,7 +378,7 @@ XIC_plot_module <- function(Spectronaut_report_path = NULL,
   merged_extracted_data_unnested_tmp1 <- dplyr::left_join(merged_extracted_data_unnested,
                                                            result_runTable %>%
                                                             rowwise() %>%
-                                                            mutate(RawFileName = stringr::str_remove(RawFileName, "\\.(raw|d|wiff)$")) %>%
+                                                            mutate(RawFileName = stringr::str_remove(RawFileName, "\\.(raw|d|wiff|wiff2|htrms|mzML|mzXML|tdf)$")) %>%
                                                             ungroup(),
                                                            by = c("Run_ID" = "ID"))
 


### PR DESCRIPTION
## Summary

Commit 5d47896 (\"add workaround for XIC plot if a `.` is used in raw file naming\") narrowed the suffix-strip regex in `XIC_plot_module()` to `\\.(raw|d|wiff)$`. The bundled HYE demo data — and any timsTOF run that goes through Spectronaut's pipeline mode — stores `Run.RawFileName` with a `.htrms` extension, which the new regex does not match. The left-join against the report's `R.FileName` (which has no extension) then mismatches every row, `R.Condition` / `R.Replicate` come back `NA`, and `facet_grid()` collapses every trace into a single phantom `NA / NA` panel instead of the per-run panels the vignette shows.

This PR extends the regex to cover the common vendor / intermediate extensions: `raw|d|wiff|wiff2|htrms|mzML|mzXML|tdf`.

## Reproduction (current `main`)

```r
library(SpectroPipeR)
XIC_plot_module(
  Spectronaut_report_path = system.file(\"extdata/HYE_demo_data\",
                                        \"HYE_demo_data_Report_SpectroPipeR.tsv\",
                                        package = \"SpectroPipeR\"),
  Spectronaut_xicDB_path  = system.file(\"extdata/HYE_demo_data/XIC_DBs\",
                                        package = \"SpectroPipeR\"),
  protein_groups          = c(\"P29311\", \"P38720\"),
  output_path             = tempfile(\"xic_demo_\"),
  export_csv_files        = TRUE,
  number_of_cores         = 2
)
```

The two PDFs are produced without error, but every ion trace ends up in a trailing `NA / NA` panel; the eight expected `HYE mix A 1..4` / `HYE mix B 1..4` facets are empty. Compare against `vignettes/figures/XIC_example.png`.

Confirmed by inspecting the SQLite \"Run\" table in any of the bundled `XIC_DBs/file*.xic.db`:

```
$ sqlite3 inst/extdata/HYE_demo_data/XIC_DBs/file1.xic.db \"SELECT * FROM Run;\"
0|20230314_TIMS1_SM_Protoc_OT2_A_400ng_R1_S1-A5_1_6354.htrms
```

and the report's `R.FileName` column (no extension):

```
20230314_TIMS1_SM_Protoc_OT2_A_400ng_R1_S1-A5_1_6354
```

## Fix

One-line change in `R/XIC_plot_module.R` (the `left_join` against `result_runTable`):

```diff
- mutate(RawFileName = stringr::str_remove(RawFileName, \"\\\\.(raw|d|wiff)\$\"))
+ mutate(RawFileName = stringr::str_remove(RawFileName, \"\\\\.(raw|d|wiff|wiff2|htrms|mzML|mzXML|tdf)\$\"))
```

This still strips only the final, known extension (so it preserves the original commit's intent of tolerating dots inside the stem), but now covers `.htrms` plus other common vendor/intermediate formats.

An alternative — `\"\\\\.[A-Za-z0-9]+\$\"` (strip any final extension-like token) — is more permissive and would not require future maintenance when new vendors ship; happy to switch to that if you prefer.

## Verification

- Rebuilt and reinstalled locally (R 4.4, macOS arm64 conda env and a linux/amd64 Docker image).
- `XIC_plot_module()` on the bundled HYE demo now produces the same eight-panel layout shown in `vignettes/figures/XIC_example.png`. Per-protein PDF and CSV outputs are sized and shaped as expected (PDFs ~52 kB, CSVs ~1.3 MB for the two demo protein groups).
- Diff: 1 file changed, 1 insertion(+), 1 deletion(-).

## Test plan

- [x] Demo (`inst/extdata/HYE_demo_data`) produces the expected eight-panel XIC PDF.
- [x] No `NA / NA` facet in output.
- [x] CSV export contains rows for all 8 runs (HYE mix A 1..4 and HYE mix B 1..4).