### PR TITLE
chore: Docker containerization with smoke tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Default-deny build context — allowlist only what the Dockerfile needs.
+*
+
+# Image build scaffolding
+!environment.yml
+!Dockerfile
+!docker/
+
+# Package source (used when --build-arg SPECTROPIPER_LOCAL=true)
+!DESCRIPTION
+!NAMESPACE
+!NEWS.md
+!LICENSE
+!LICENSE.md
+!R/
+!inst/
+!man/
+
+# Belt-and-braces: keep large untracked dirs out even if accidentally added above
+data/
+docs/
+pkgdown/
+tests/
+vignettes/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+# Pinned to linux/amd64 so the same image works on x86 Linux hosts AND on
+# Apple Silicon Macs (via Docker Desktop's Rosetta emulation). This is
+# required because several conda-forge / bioconda packages used here
+# (quarto, r-umap, parts of the PECA chain) are not built for linux/arm64.
+FROM --platform=linux/amd64 condaforge/miniforge3:latest
+
+ENV ENV_NAME=spectropiper
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System libs needed for any R packages that fall through to source compile
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        gfortran \
+        libxml2-dev \
+        libssl-dev \
+        libcurl4-openssl-dev \
+        libfontconfig1-dev \
+        libfreetype6-dev \
+        libpng-dev \
+        libtiff5-dev \
+        libjpeg-dev \
+        libharfbuzz-dev \
+        libfribidi-dev \
+        zlib1g-dev \
+        ca-certificates \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/SpectroPipeR
+
+# 1. Build conda env from environment.yml (CRAN + Bioc deps as binaries,
+#    including the PECA transitive chain — see comments in environment.yml)
+COPY environment.yml .
+RUN mamba env create -n ${ENV_NAME} -f environment.yml \
+    && mamba clean -afy
+
+# Put the env's binaries first on PATH so plain `R` / `Rscript` use the env.
+# Simpler and more reliable than wrapping every RUN in `mamba run`.
+ENV PATH=/opt/conda/envs/spectropiper/bin:$PATH
+
+# 2. iq (not packaged for conda) and ROTS/PECA via R/BiocManager
+RUN Rscript -e 'options(repos = c(CRAN = "https://cloud.r-project.org")); \
+        if (!requireNamespace("BiocManager", quietly = TRUE)) install.packages("BiocManager"); \
+        install.packages("iq"); \
+        BiocManager::install(c("ROTS","PECA"), update = FALSE, ask = FALSE); \
+        stopifnot(requireNamespace("iq"), requireNamespace("PECA"))'
+
+# 3. Install SpectroPipeR.
+#    Default: pull from GitHub. Override the ref at build time with
+#      `--build-arg SPECTROPIPER_REF=<branch|tag|sha>`.
+#    Or install the local checkout (useful for testing un-pushed patches):
+#      `--build-arg SPECTROPIPER_LOCAL=true`
+ARG SPECTROPIPER_REPO=stemicha/SpectroPipeR
+ARG SPECTROPIPER_REF=main
+ARG SPECTROPIPER_LOCAL=false
+# Always copy the local checkout into the image — the build context is
+# kept tiny by .dockerignore, so this is cheap. It's used only when
+# SPECTROPIPER_LOCAL=true.
+COPY DESCRIPTION NAMESPACE NEWS.md LICENSE LICENSE.md /opt/SpectroPipeR/pkg/
+COPY R    /opt/SpectroPipeR/pkg/R/
+COPY inst /opt/SpectroPipeR/pkg/inst/
+COPY man  /opt/SpectroPipeR/pkg/man/
+RUN if [ "$SPECTROPIPER_LOCAL" = "true" ]; then \
+        echo "Installing SpectroPipeR from local checkout..." && \
+        Rscript -e 'remotes::install_local("/opt/SpectroPipeR/pkg", upgrade="never", dependencies=FALSE); stopifnot(requireNamespace("SpectroPipeR"))' ; \
+    else \
+        echo "Installing SpectroPipeR from GitHub ${SPECTROPIPER_REPO}@${SPECTROPIPER_REF}..." && \
+        Rscript -e "remotes::install_github('${SPECTROPIPER_REPO}', ref='${SPECTROPIPER_REF}', upgrade='never', dependencies=FALSE); stopifnot(requireNamespace('SpectroPipeR'))" ; \
+    fi
+
+# 4. Smoke test (mirrors tests/testthat/test-SpectR_test_all.R)
+COPY docker/smoke_test.R /opt/SpectroPipeR/smoke_test.R
+
+# Default: run the smoke test. `docker run --rm <image>` returns non-zero on failure.
+CMD ["Rscript", "/opt/SpectroPipeR/smoke_test.R"]

--- a/docker/smoke_test.R
+++ b/docker/smoke_test.R
@@ -1,0 +1,42 @@
+suppressPackageStartupMessages({
+  library(SpectroPipeR)
+})
+
+params <- list(
+  output_folder = tempdir(),
+  ion_q_value_cutoff = 0.001,
+  id_drop_cutoff = 0.3,
+  normalization_method = "median",
+  normalization_factor_cutoff_outlier = 4,
+  filter_oxidized_peptides = TRUE,
+  protein_intensity_estimation = "MaxLFQ",
+  stat_test = "modt",
+  type_slr = "median",
+  fold_change = 1.5,
+  p_value_cutoff = 0.05,
+  paired = FALSE
+)
+
+example_file_path <- system.file("extdata", "SN_test_HYE_mix_file.tsv", package = "SpectroPipeR")
+if (!nzchar(example_file_path)) stop("bundled HYE example file not found in installed package")
+
+cat("\n=== STEP 1: read_spectronaut_module ===\n")
+d <- read_spectronaut_module(file = example_file_path, parameter = params, print.plot = FALSE)
+stopifnot(!is.null(d))
+
+cat("\n=== STEP 2: norm_quant_module ===\n")
+q <- norm_quant_module(SpectroPipeR_data = d)
+stopifnot(!is.null(q))
+
+cat("\n=== STEP 3: MVA_module ===\n")
+m <- MVA_module(SpectroPipeR_data_quant = q, HCPC_analysis = FALSE)
+stopifnot(!is.null(m))
+
+cat("\n=== STEP 4: statistics_module ===\n")
+s <- statistics_module(
+  SpectroPipeR_data_quant = q,
+  condition_comparisons = cbind(c("HYE mix A", "HYE mix B"))
+)
+stopifnot(!is.null(s))
+
+cat("\n=== ALL MODULES PASSED ===\n")

--- a/docker/xic_smoke_test.R
+++ b/docker/xic_smoke_test.R
@@ -1,0 +1,46 @@
+suppressPackageStartupMessages({
+  library(SpectroPipeR)
+})
+
+# Output dir override (env var) so we can run this on host or in container
+out_dir <- Sys.getenv("XIC_OUT_DIR", unset = file.path(tempdir(), "xic_smoke_out"))
+dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+
+Spectronaut_report_path <- system.file(
+  "extdata/HYE_demo_data", "HYE_demo_data_Report_SpectroPipeR.tsv",
+  package = "SpectroPipeR"
+)
+Spectronaut_xicDB_path  <- system.file(
+  "extdata/HYE_demo_data/XIC_DBs",
+  package = "SpectroPipeR"
+)
+stopifnot(nzchar(Spectronaut_report_path), file.exists(Spectronaut_report_path))
+stopifnot(nzchar(Spectronaut_xicDB_path),  dir.exists(Spectronaut_xicDB_path))
+stopifnot(length(list.files(Spectronaut_xicDB_path, pattern = "\\.db$")) >= 1)
+
+cat("\n=== XIC_plot_module ===\n")
+cat("report : ", Spectronaut_report_path, "\n")
+cat("xic db : ", Spectronaut_xicDB_path,  "\n")
+cat("out    : ", out_dir, "\n\n")
+
+XIC_plot_module(
+  Spectronaut_report_path = Spectronaut_report_path,
+  Spectronaut_xicDB_path  = Spectronaut_xicDB_path,
+  protein_groups          = c("P29311", "P38720"),
+  output_path             = out_dir,
+  export_csv_files        = TRUE,
+  number_of_cores         = 2
+)
+
+pdfs <- list.files(out_dir, pattern = "\\.pdf$", recursive = TRUE, full.names = TRUE)
+csvs <- list.files(out_dir, pattern = "\\.csv$", recursive = TRUE, full.names = TRUE)
+
+cat("\nproduced PDFs:\n"); for (f in pdfs) cat(" -", f, "(", file.info(f)$size, "bytes )\n")
+cat("\nproduced CSVs:\n"); for (f in csvs) cat(" -", f, "(", file.info(f)$size, "bytes )\n")
+
+if (length(pdfs) == 0) stop("XIC_plot_module produced no PDF files")
+if (length(csvs) == 0) stop("XIC_plot_module produced no CSV files (export_csv_files = TRUE)")
+if (any(file.info(pdfs)$size == 0)) stop("at least one PDF is 0 bytes")
+
+cat("\n=== XIC PLOT TEST PASSED ===\n")
+cat("PDFs:", length(pdfs), " CSVs:", length(csvs), "\n")

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,65 @@
+name: spectropiper
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - r-base>=4.4
+  - quarto
+  - pandoc
+  - make
+  - r-devtools
+  - r-remotes
+  - r-testthat
+  - r-systemfonts
+  # tidyverse umbrella (dplyr, ggplot2, tibble, tidyr, readr, purrr, stringr, forcats, lubridate)
+  - r-tidyverse
+  # core deps
+  - r-base64enc
+  - r-broom
+  - r-bslib
+  - r-crayon
+  - r-doparallel
+  - r-dosnow
+  - r-dt
+  - r-effsize
+  - r-factoextra
+  - r-factominer
+  - r-foreach
+  - r-future
+  - r-ggally
+  - r-ggcorrplot
+  - r-gghalves
+  - r-ggrepel
+  - r-hexbin
+  - r-htmltools
+  - r-htmlwidgets
+  - r-kableextra
+  - r-knitr
+  - r-modelr
+  - r-openxlsx
+  - r-patchwork
+  - r-plotly
+  - r-quarto
+  - r-readxl
+  - r-reticulate
+  - r-reshape2
+  - r-rlang
+  - r-rmarkdown
+  - r-rsqlite
+  - r-scales
+  - r-shiny
+  - r-summarytools
+  - r-umap
+  - r-upsetr
+  # Bioconductor
+  - bioconductor-biocparallel
+  - bioconductor-sva
+  # PECA's transitive chain — installed as conda binaries to avoid Fortran
+  # source compiles. PECA itself + ROTS + iq are installed via R afterwards
+  # (PECA's conda recipe pins to bioconductor-rots which isn't on every arch;
+  # r-iq is not packaged for conda at all).
+  - bioconductor-affy
+  - bioconductor-dnacopy
+  - r-pscbs
+  - r-aroma.core
+  - r-aroma.affymetrix


### PR DESCRIPTION
Containerized build for SpectroPipeR with two smoke tests.

- `Dockerfile` — miniforge3 base (amd64), conda env + iq/ROTS/PECA, installs from GitHub or local checkout.
- `environment.yml` — conda deps, incl. PECA's Fortran chain as binaries.
- `.dockerignore` — default-deny allowlist.
- `docker/smoke_test.R` — read/norm_quant/MVA/statistics on the bundled HYE example.
- `docker/xic_smoke_test.R` — XIC_plot_module, checks PDF/CSV output.

**Tested on Mac (Apple Silicon, amd64 image under Rosetta emulation via Docker Desktop) only.** Not verified on x86_64 Linux or Windows.